### PR TITLE
Fix select data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG.md
 
+## 0.1.8 (2023-01-18)
+
+- Made getItemValue prop optional in TypeaheadSelect and FormSelect components.
+  Default behavior will be setting the form value to the entire data object.
+
 ## 0.1.7 (2023-01-18)
 
 - Added react-hook-form as external dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stratosphere-ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stratosphere-ui",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.20.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratosphere-ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "React component library for all Stratosphere Labs user interfaces",
   "type": "module",
   "files": [

--- a/src/components/Form/FormSelect.stories.tsx
+++ b/src/components/Form/FormSelect.stories.tsx
@@ -36,7 +36,6 @@ Default.args = {
   labelText: 'Field Label',
   name: 'field1',
   getItemText: ({ id, label }) => `${id} - ${label}`,
-  getItemValue: ({ id }) => id,
   options: [
     {
       id: '1',

--- a/src/components/Form/FormSelect.tsx
+++ b/src/components/Form/FormSelect.tsx
@@ -53,6 +53,7 @@ export const FormSelect = <
   return (
     <Listbox
       as="div"
+      by="id"
       className={classNames('flex flex-col', className)}
       name={name}
       onChange={setSelectedItem}

--- a/src/components/Form/FormSelect.tsx
+++ b/src/components/Form/FormSelect.tsx
@@ -25,7 +25,7 @@ export interface FormSelectProps<
   className?: string;
   dropdownIcon?: FC<ComponentProps<'svg'>>;
   getItemText: (data: DataItem) => string;
-  getItemValue: (data: DataItem) => string;
+  getItemValue?: (data: DataItem) => string;
   options: DataItem[];
 }
 
@@ -46,7 +46,9 @@ export const FormSelect = <
   const { setValue } = useFormContext();
   const [selectedItem, setSelectedItem] = useState<DataItem>(options[0]);
   useEffect(() => {
-    setValue<string>(name, getItemValue(selectedItem), {
+    const itemValue =
+      getItemValue !== undefined ? getItemValue(selectedItem) : selectedItem;
+    setValue<string>(name, itemValue, {
       shouldValidate: true,
     });
   }, [selectedItem]);

--- a/src/components/Typeahead/Typeahead.stories.tsx
+++ b/src/components/Typeahead/Typeahead.stories.tsx
@@ -38,7 +38,6 @@ SingleSelect.args = {
   labelText: 'Field Label',
   name: 'field1',
   getItemText: ({ label }) => label,
-  getItemValue: ({ value }) => value,
   options: [
     { id: '1', label: 'Item 1' },
     { id: '2', label: 'Item 2' },
@@ -62,7 +61,6 @@ MultiSelect.args = {
   labelText: 'Field Label',
   name: 'field1',
   getItemText: ({ label }) => label,
-  getItemValue: ({ id }) => id,
   options: [
     { id: '1', label: 'Item 1' },
     { id: '2', label: 'Item 2' },

--- a/src/components/Typeahead/TypeaheadMultiSelect.tsx
+++ b/src/components/Typeahead/TypeaheadMultiSelect.tsx
@@ -22,6 +22,7 @@ export const TypeaheadMultiSelect = <
   className,
   controllerProps,
   debounceTime,
+  getBadgeText,
   getItemText,
   getItemValue,
   inputRef,
@@ -49,7 +50,9 @@ export const TypeaheadMultiSelect = <
     options,
   });
   useEffect(() => {
-    const itemValues = selectedItems.map(getItemValue);
+    const itemValues = getItemValue
+      ? selectedItems.map(getItemValue)
+      : selectedItems;
     setValue<string>(name, itemValues, {
       shouldValidate: true,
     });
@@ -73,9 +76,7 @@ export const TypeaheadMultiSelect = <
         </Combobox.Label>
       ) : null}
       <div
-        className={classNames(
-          'input-bordered input-ghost input flex cursor-pointer items-center gap-2 overflow-y-scroll',
-        )}
+        className="input-bordered input-ghost input flex cursor-pointer items-center gap-2 overflow-y-scroll"
         onBlur={event => {
           if (event.relatedTarget === null) setShowDropdown(false);
         }}
@@ -100,7 +101,7 @@ export const TypeaheadMultiSelect = <
                   )
                 }
               >
-                {getItemValue(item)}
+                {getBadgeText?.(item) ?? item.id}
               </Badge>
             ))
           : placeholder}

--- a/src/components/Typeahead/TypeaheadSelect.tsx
+++ b/src/components/Typeahead/TypeaheadSelect.tsx
@@ -12,8 +12,9 @@ export interface TypeaheadSelectProps<
 > extends UseTypeaheadInputOptions<DataItem>,
     FormFieldProps<Values> {
   className?: string;
+  getBadgeText?: (item: DataItem) => string;
   getItemText: (data: DataItem) => string;
-  getItemValue: (data: DataItem) => string;
+  getItemValue?: (data: DataItem) => string;
   inputRef?: RefObject<HTMLInputElement>;
   multi?: true;
 }

--- a/src/components/Typeahead/TypeaheadSingleSelect.tsx
+++ b/src/components/Typeahead/TypeaheadSingleSelect.tsx
@@ -46,7 +46,12 @@ export const TypeaheadSingleSelect = <
     options,
   });
   useEffect(() => {
-    const itemValue = selectedItem !== null ? getItemValue(selectedItem) : '';
+    const itemValue =
+      getItemValue !== undefined
+        ? selectedItem !== null
+          ? getItemValue(selectedItem)
+          : ''
+        : selectedItem;
     setValue<string>(name, itemValue, {
       shouldValidate: selectedItem !== null,
     });


### PR DESCRIPTION
- Changed `getItemValue` prop to be optional in FormSelect and TypeaheadSelect components. Default behavior is setting the form value to the entire data object that is passed in the `options` prop.
- Fixed bug in FormSelect component where current selected value does not show.